### PR TITLE
chore: update ras-stack tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup JavaScript
-        uses: richardsolomou/ras-stack/actions/setup-js@v0.8.3
+        uses: richardsolomou/ras-stack/actions/setup-js@v0.39.1
 
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup JavaScript
-        uses: richardsolomou/ras-stack/actions/setup-js@v0.8.3
+        uses: richardsolomou/ras-stack/actions/setup-js@v0.39.1
 
       # TODO: Uncomment this for your own repository
       # - name: Run Changesets (version or publish)

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "changeset:publish": "pnpm build && changeset publish",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "policy:check": "ras-stack-policy check"
+    "policy:check": "ras policy check"
   },
   "devDependencies": {
     "@changesets/cli": "^2.31.1",
@@ -88,7 +88,7 @@
     "oxlint": "^1.77.0",
     "oxlint-tsgolint": "^7.0.2001",
     "playwright": "^1.62.1",
-    "ras-stack": "^0.8.2",
+    "ras-stack": "^0.39.1",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "storybook": "^10.5.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ importers:
         specifier: ^1.62.1
         version: 1.62.1
       ras-stack:
-        specifier: ^0.8.2
-        version: 0.8.2
+        specifier: ^0.39.1
+        version: 0.39.1(@types/node@26.2.0)(react@19.2.8)
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -630,9 +630,53 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@inquirer/ansi@2.0.7':
+    resolution: {integrity: sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+
+  '@inquirer/confirm@6.1.1':
+    resolution: {integrity: sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@11.2.1':
+    resolution: {integrity: sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/external-editor@1.0.3':
     resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
     engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@2.0.7':
+    resolution: {integrity: sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+
+  '@inquirer/select@5.2.1':
+    resolution: {integrity: sha512-FlDndEUww8m7BfukO2nJa25vhD+H5jxxCv4oGioKqzyWz3nPHhhw4LKdYRSlXuAx7DsdWia7iyaBPKKS95Evfw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/type@4.0.7':
+    resolution: {integrity: sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -2196,6 +2240,10 @@ packages:
       '@chromatic-com/vitest':
         optional: true
 
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
@@ -2344,6 +2392,15 @@ packages:
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
+
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
+  fast-wrap-ansi@0.2.2:
+    resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -2752,6 +2809,10 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  mute-stream@3.0.0:
+    resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   nanoid@3.3.18:
     resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -2916,24 +2977,57 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
-  ras-stack@0.8.2:
-    resolution: {integrity: sha512-zu7qxodt1Hoy6AKLnglGVULKaoyRni8hHZZ7btgkqbU4HQdecODfCXmAdN/pwFYW1VOY3YwpYGAWK5/I8CEHjw==}
+  ras-stack@0.39.1:
+    resolution: {integrity: sha512-lESs76kS02jg9s4/FtWKG+Ha1vVjEgozmG8dF0Tlr3ZpK+NOraBIho+NnTX2riBp0N7hNv/GNZnoz3NpvZrTDQ==}
     engines: {node: '>=24 <25'}
     hasBin: true
     peerDependencies:
+      '@opentelemetry/api-logs': ^0.221.0
+      '@opentelemetry/exporter-logs-otlp-http': ^0.221.0
+      '@opentelemetry/resources': ^2.10.0
+      '@opentelemetry/sdk-logs': ^0.221.0
+      '@posthog/react': '>=1 <2'
       '@tanstack/react-query': '>=5 <6'
       '@tanstack/react-start': '>=1 <2'
+      better-sqlite3: '>=12 <14'
       centrifuge: '>=5 <6'
+      drizzle-orm: '>=0.45 <1'
       nodemailer: '>=9 <10'
+      postgres: '>=3.4 <4'
+      posthog-js: '>=1.407 <2'
+      posthog-node: '>=5.47 <6'
+      react: '>=19 <20'
       tus-js-client: '>=4 <5'
     peerDependenciesMeta:
+      '@opentelemetry/api-logs':
+        optional: true
+      '@opentelemetry/exporter-logs-otlp-http':
+        optional: true
+      '@opentelemetry/resources':
+        optional: true
+      '@opentelemetry/sdk-logs':
+        optional: true
+      '@posthog/react':
+        optional: true
       '@tanstack/react-query':
         optional: true
       '@tanstack/react-start':
         optional: true
+      better-sqlite3:
+        optional: true
       centrifuge:
         optional: true
+      drizzle-orm:
+        optional: true
       nodemailer:
+        optional: true
+      postgres:
+        optional: true
+      posthog-js:
+        optional: true
+      posthog-node:
+        optional: true
+      react:
         optional: true
       tus-js-client:
         optional: true
@@ -3962,10 +4056,46 @@ snapshots:
 
   '@exodus/bytes@1.15.1': {}
 
+  '@inquirer/ansi@2.0.7': {}
+
+  '@inquirer/confirm@6.1.1(@types/node@26.2.0)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@26.2.0)
+      '@inquirer/type': 4.0.7(@types/node@26.2.0)
+    optionalDependencies:
+      '@types/node': 26.2.0
+
+  '@inquirer/core@11.2.1(@types/node@26.2.0)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@26.2.0)
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.2
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
+    optionalDependencies:
+      '@types/node': 26.2.0
+
   '@inquirer/external-editor@1.0.3(@types/node@26.2.0)':
     dependencies:
       chardet: 2.2.0
       iconv-lite: 0.7.3
+    optionalDependencies:
+      '@types/node': 26.2.0
+
+  '@inquirer/figures@2.0.7': {}
+
+  '@inquirer/select@5.2.1(@types/node@26.2.0)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 11.2.1(@types/node@26.2.0)
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@26.2.0)
+    optionalDependencies:
+      '@types/node': 26.2.0
+
+  '@inquirer/type@4.0.7(@types/node@26.2.0)':
     optionalDependencies:
       '@types/node': 26.2.0
 
@@ -5054,6 +5184,8 @@ snapshots:
     dependencies:
       semver: 7.8.5
 
+  cli-width@4.1.0: {}
+
   convert-source-map@2.0.0: {}
 
   cross-spawn@7.0.6:
@@ -5218,6 +5350,16 @@ snapshots:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.8
+
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
+  fast-wrap-ansi@0.2.2:
+    dependencies:
+      fast-string-width: 3.0.2
 
   fastq@1.20.1:
     dependencies:
@@ -5568,6 +5710,8 @@ snapshots:
 
   ms@2.1.3: {}
 
+  mute-stream@3.0.0: {}
+
   nanoid@3.3.18: {}
 
   node-releases@2.0.53: {}
@@ -5767,9 +5911,15 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  ras-stack@0.8.2:
+  ras-stack@0.39.1(@types/node@26.2.0)(react@19.2.8):
     dependencies:
+      '@inquirer/confirm': 6.1.1(@types/node@26.2.0)
+      '@inquirer/select': 5.2.1(@types/node@26.2.0)
       yaml: 2.9.0
+    optionalDependencies:
+      react: 19.2.8
+    transitivePeerDependencies:
+      - '@types/node'
 
   react-docgen-typescript@2.4.0(typescript@7.0.2):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,4 +3,7 @@ allowBuilds:
   esbuild: true
   lefthook: true
 minimumReleaseAgeExclude:
-  - ras-stack@0.8.2
+  - baseline-browser-mapping@2.11.13
+  - browserslist@4.28.8
+  - ras-stack@0.39.1
+minimumReleaseAge: 10080

--- a/ras-stack.policy.json
+++ b/ras-stack.policy.json
@@ -1,4 +1,5 @@
 {
   "changesets": true,
-  "dependabot": true
+  "dependabot": true,
+  "pnpm": {}
 }


### PR DESCRIPTION
## Description

Updates the template to ras-stack 0.39.1, migrates the policy command to the current CLI, enables the shared seven-day pnpm release-age policy, and refreshes pinned workflow actions where present.

**Why:** Newly generated projects should start from the current shared tooling and policy conventions instead of the early 0.8 interface.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test updates

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (N/A, no complex logic)
- [x] I have made corresponding changes to the documentation (N/A, internal tooling only)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (N/A, configuration-only change)
- [x] New and existing unit tests pass locally with my changes
- [x] I have created a changeset (N/A, template tooling only)

## Related Issues

None.

## Additional Context

Policy synchronization now keeps the generated pnpm and Dependabot configuration aligned with ras-stack.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*