### PR TITLE
Update ras-stack to 0.39.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup JavaScript
-        uses: richardsolomou/ras-stack/actions/setup-js@v0.39.1
+        uses: richardsolomou/ras-stack/actions/setup-js@v0.39.5
 
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup JavaScript
-        uses: richardsolomou/ras-stack/actions/setup-js@v0.39.1
+        uses: richardsolomou/ras-stack/actions/setup-js@v0.39.5
 
       # TODO: Uncomment this for your own repository
       # - name: Run Changesets (version or publish)

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "oxlint": "^1.77.0",
     "oxlint-tsgolint": "^7.0.2001",
     "playwright": "^1.62.1",
-    "ras-stack": "^0.39.1",
+    "ras-stack": "^0.39.5",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "storybook": "^10.5.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ importers:
         specifier: ^1.62.1
         version: 1.62.1
       ras-stack:
-        specifier: ^0.39.1
-        version: 0.39.1(@types/node@26.2.0)(react@19.2.8)
+        specifier: ^0.39.5
+        version: 0.39.5(@types/node@26.2.0)(react@19.2.8)
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -2977,8 +2977,8 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
-  ras-stack@0.39.1:
-    resolution: {integrity: sha512-lESs76kS02jg9s4/FtWKG+Ha1vVjEgozmG8dF0Tlr3ZpK+NOraBIho+NnTX2riBp0N7hNv/GNZnoz3NpvZrTDQ==}
+  ras-stack@0.39.5:
+    resolution: {integrity: sha512-VRMFNAVOWf3Yu+5GheN4QIBPEXGFZaPIuLX6BGpxPa+ECFXF4LVzRA3ORo5m9DyR6k9kfGHPZ3AfIGd6n4Z44w==}
     engines: {node: '>=24 <25'}
     hasBin: true
     peerDependencies:
@@ -5911,7 +5911,7 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  ras-stack@0.39.1(@types/node@26.2.0)(react@19.2.8):
+  ras-stack@0.39.5(@types/node@26.2.0)(react@19.2.8):
     dependencies:
       '@inquirer/confirm': 6.1.1(@types/node@26.2.0)
       '@inquirer/select': 5.2.1(@types/node@26.2.0)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,5 +5,5 @@ allowBuilds:
 minimumReleaseAgeExclude:
   - baseline-browser-mapping@2.11.13
   - browserslist@4.28.8
-  - ras-stack@0.39.1
+  - ras-stack@0.39.5
 minimumReleaseAge: 10080


### PR DESCRIPTION
## Description

Updates ras-stack and generated workflow pins to v0.39.5.

Why: This keeps Dependabot updates compatible with the repository minimum-release-age policy and repaired reusable workflows.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have created a changeset (if applicable)

## Related Issues

None.

## Additional Context

Validated with pnpm check.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*